### PR TITLE
Guard on_refresh_rate_changed against ValueError from non-numeric value

### DIFF
--- a/actions/Contributions.py
+++ b/actions/Contributions.py
@@ -261,9 +261,9 @@ class ContributionsActions(ActionCore):
         plugin_settings = self.plugin_base.get_settings()
         if hasattr(value, "get_value"):
             value = value.get_value()
-        if value is not None:
-            new_refresh_rate = int(value)
-        else:
+        try:
+            new_refresh_rate = int(value) if value is not None else int(plugin_settings.get("refresh_rate", "0"))
+        except (ValueError, TypeError):
             new_refresh_rate = int(plugin_settings.get("refresh_rate", "0"))
 
         # Always update plugin's settings immediately


### PR DESCRIPTION
int(value) had no exception handling, so an empty string or unexpected type from ComboRow (e.g. during widget initialisation before any item is selected) would crash the handler before start_refresh_timer() ran, leaving the timer in an inconsistent state. Falls back to the persisted refresh_rate on any conversion failure.